### PR TITLE
Disable sending PII to Sentry

### DIFF
--- a/src/backend/settings/production.py
+++ b/src/backend/settings/production.py
@@ -33,7 +33,7 @@ MAIL = {
 sentry_sdk.init(
     dsn="https://beaf099a91144f74afac77c0afe70518@o430159.ingest.sentry.io/5378144",
     integrations=[DjangoIntegration()],
-    send_default_pii=True
+    send_default_pii=False
 )
 
 REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"].update({

--- a/src/backend/settings/production.py
+++ b/src/backend/settings/production.py
@@ -33,7 +33,8 @@ MAIL = {
 sentry_sdk.init(
     dsn="https://beaf099a91144f74afac77c0afe70518@o430159.ingest.sentry.io/5378144",
     integrations=[DjangoIntegration()],
-    send_default_pii=False
+    send_default_pii=False,
+    server_name=DOMAIN,
 )
 
 REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"].update({


### PR DESCRIPTION
Given that errors raised by Sentry will most likely come from client `docker-compose` setups, the issues themselves intrinsically don't require PII to fix. This PR disables sending PII to our Sentry environment.