### PR TITLE
Push Docker images on tags.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -14,9 +13,15 @@ jobs:
       shell: bash
       run: echo "##[set-output name=name;]`echo ${GITHUB_REF#refs/tags/}`"
       id: branch
+      if: startsWith(github.ref, 'refs/tags/')
 
-    - name: Build Docker Container
+    - name: Build untagged Docker container
+      run: docker build .
+      if: startsWith(github.ref, 'refs/tags/') != true
+
+    - name: Build tagged Docker Container
       run: docker build -t ractf/core:${{ steps.branch.outputs.name }} -t ghcr.io/ractf/core:${{ steps.branch.outputs.name }} -t ractf/core:latest -t ghcr.io/ractf/core:latest .
+      if: startsWith(github.ref, 'refs/tags/')
 
     - name: Create Sentry release
       uses: getsentry/action-release@v1
@@ -24,19 +29,27 @@ jobs:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+      if: startsWith(github.ref, 'refs/tags/')
 
     - name: Login to Docker Hub
       run: docker login --username ractf --password ${{ secrets.password }}
+      if: startsWith(github.ref, 'refs/tags/')
+
 
     - name: Login to Github Container Registry
       run: echo ${{ secrets.ghtoken }} | docker login ghcr.io -u ${{ secrets.ghuser }} --password-stdin
+      if: startsWith(github.ref, 'refs/tags/')
+
 
     - name: Push to Docker Hub
       run: |
           docker push ractf/core:${{ steps.branch.outputs.name }}
           docker push ractf/core:latest
+      if: startsWith(github.ref, 'refs/tags/')
+
 
     - name: Push to Github Container Registry
       run: |
           docker push ghcr.io/ractf/core:${{ steps.branch.outputs.name }}
           docker push ghcr.io/ractf/core:latest
+      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,38 +5,38 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Get branch name
+    - name: Get version name
       shell: bash
-      run: echo "##[set-output name=name;]`echo $([ ${GITHUB_REF#refs/heads/} = "master" ] && echo 'latest' || echo ${GITHUB_REF#refs/heads/}) | sed 's/\//-/g'`"
+      run: echo "##[set-output name=name;]`echo ${GITHUB_REF#refs/tags/}`"
       id: branch
 
     - name: Build Docker Container
-      run: docker build -t ractf/core:${{ steps.branch.outputs.name }} -t ghcr.io/ractf/core:${{ steps.branch.outputs.name }} .
+      run: docker build -t ractf/core:${{ steps.branch.outputs.name }} -t ghcr.io/ractf/core:${{ steps.branch.outputs.name }} -t ractf/core:latest -t ghcr.io/ractf/core:latest .
 
     - name: Create Sentry release
       uses: getsentry/action-release@v1
-      if: github.ref == 'refs/heads/master'
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
     - name: Login to Docker Hub
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
       run: docker login --username ractf --password ${{ secrets.password }}
 
     - name: Login to Github Container Registry
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
       run: echo ${{ secrets.ghtoken }} | docker login ghcr.io -u ${{ secrets.ghuser }} --password-stdin
 
     - name: Push to Docker Hub
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
-      run: docker push ractf/core:${{ steps.branch.outputs.name }}
+      run: |
+          docker push ractf/core:${{ steps.branch.outputs.name }}
+          docker push ractf/core:latest
 
     - name: Push to Github Container Registry
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
-      run: docker push ghcr.io/ractf/core:${{ steps.branch.outputs.name }}
+      run: |
+          docker push ghcr.io/ractf/core:${{ steps.branch.outputs.name }}
+          docker push ghcr.io/ractf/core:latest


### PR DESCRIPTION
A new Docker image is pushed for every tag. Naturally, this means that tags
should likely be protected in the Repository settings somehow, unless
contributors are trusted.

In addition to the tagged Docker image push, the `latest` image is pushed on
every new tag.