### PR TITLE
Rename FastPagination To FormattedPagination.

### DIFF
--- a/src/backend/pagination.py
+++ b/src/backend/pagination.py
@@ -5,19 +5,15 @@ from rest_framework.pagination import LimitOffsetPagination
 from backend.response import FormattedResponse
 
 
-class FastPagination(LimitOffsetPagination):
+class FormattedPagination(LimitOffsetPagination):
     def get_paginated_response(self, data):
         return FormattedResponse(
             OrderedDict(
                 [
-                    ("next", self.format_link(self.get_next_link())),
-                    ("previous", self.format_link(self.get_previous_link())),
+                    ("next", self.get_next_link()),
+                    ("previous", self.get_previous_link()),
                     ("results", data),
                     ("count", self.count),
                 ]
             )
         )
-
-    @staticmethod
-    def format_link(result):
-        return result if result is None else result.replace(".co.uk", ".co.uk/api/v2")

--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -276,7 +276,7 @@ REST_FRAMEWORK = {
         "polaris_view_hosts": "100/minute",
         "polaris_view_instances": "100/minute",
     },
-    "DEFAULT_PAGINATION_CLASS": "backend.pagination.FastPagination",
+    "DEFAULT_PAGINATION_CLASS": "backend.pagination.FormattedPagination",
     "PAGE_SIZE": 100,
 }
 


### PR DESCRIPTION
Also removes the URL rewrite, this was necessary when we used to have broken url rewrite rules on nginx however this hasn't been the case for quite a while, and it assumed you were on a .co.uk domain, core has worked on domains that aren't .co.uk so this is fine to remove.