### PR TITLE
Start of event optimisations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ dev-test: dev-server
 	docker-compose exec backend pytest --cov=src src
 
 fake-data:
-	python -m scripts/fake generate $(ARGS)
+	python -m scripts.fake generate $(ARGS)
 
 fake-bulk-data:
 	python -m scripts.fake generate --teams 10000 --users 2 --categories 10 --challenges 100 --solves 1000000

--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -280,6 +280,7 @@ REST_FRAMEWORK = {
     },
     "DEFAULT_PAGINATION_CLASS": "backend.pagination.FormattedPagination",
     "PAGE_SIZE": 100,
+    "NUM_PROXIES": os.getenv("NUM_PROXIES", 0),
 }
 
 MAIL_SOCK_URL = "http+unix://%2Ftmp%2Fmailusv.sock/send"

--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -73,6 +73,7 @@ DEFAULT_CONFIG = {
     "enable_prelogin": True,
     "enable_maintenance_mode": False,
     "enable_registration": True,
+    "enable_preevent_cache": True,
     "enable_scoreboard": True,
     "enable_scoring": True,
     "enable_solve_broadcast": True,

--- a/src/challenge/views.py
+++ b/src/challenge/views.py
@@ -300,13 +300,13 @@ class FlagSubmitView(APIView):
             solve = challenge.points_plugin.score(user, team, flag, solve_set)
             if challenge.first_blood is None:
                 challenge.first_blood = user
-                challenge.save()
+                challenge.save(update_fields=["first_blood"])
                 hook = config.get("firstblood_webhook")
                 if hook and hook != "":
                     challenge_clean = challenge.name.replace("`", "").replace("@", "@\u200b")
                     team_clean = team.name.replace("`", "").replace("@", "@\u200b")
                     if "discord.com" in hook and not hook.endswith("/slack"):
-                        hook = hook + "/slack"
+                        hook += "/slack"
                     challenge_clean = challenge_clean.replace("@", "@\u200b")
                     team_clean = team_clean.replace("@", "@\u200b")
                     body = {

--- a/src/challenge/views.py
+++ b/src/challenge/views.py
@@ -84,7 +84,7 @@ class CategoryViewset(AdminCreateModelViewSet):
                     output_field=models.BooleanField(),
                 )
             )
-            .prefetch_related(
+                .prefetch_related(
                 Prefetch(
                     "hint_set",
                     queryset=Hint.objects.annotate(
@@ -106,7 +106,7 @@ class CategoryViewset(AdminCreateModelViewSet):
                 ),
                 "hint_set__uses",
             )
-            .select_related("first_blood")
+                .select_related("first_blood")
         )
         if self.request.user.is_staff:
             categories = Category.objects
@@ -117,6 +117,9 @@ class CategoryViewset(AdminCreateModelViewSet):
 
     def list(self, request, *args, **kwargs):
         cache = caches["default"]
+        if config.get("enable_caching") and config.get("start_time") + 15 > time.time() and "preevent_cache" in cache:
+            return FormattedResponse(cache.get("preevent_cache"))
+
         categories = cache.get(get_cache_key(request.user))
         if categories is None or not config.get("enable_caching"):
             queryset = self.filter_queryset(self.get_queryset())
@@ -162,27 +165,27 @@ class ScoresViewset(ModelViewSet):
         if user:
             user = get_object_or_404(get_user_model(), id=user)
             user.leaderboard_points = (
-                Score.objects.filter(user=user, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
+                    Score.objects.filter(user=user, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
             )
             user.points = Score.objects.filter(user=user).aggregate(Sum("points"))["points__sum"] or 0
             user.last_score = (
                 Score.objects.filter(user=user, leaderboard=True, tiebreaker=True)
-                .order_by("timestamp")
-                .first()
-                .timestamp
+                    .order_by("timestamp")
+                    .first()
+                    .timestamp
             )
             user.save()
         if team:
             team = get_object_or_404(Team, id=team)
             team.leaderboard_points = (
-                Score.objects.filter(team=team, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
+                    Score.objects.filter(team=team, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
             )
             team.points = Score.objects.filter(team=team).aggregate(Sum("points"))["points__sum"] or 0
             team.last_score = (
                 Score.objects.filter(team=team, leaderboard=True, tiebreaker=True)
-                .order_by("timestamp")
-                .first()
-                .timestamp
+                    .order_by("timestamp")
+                    .first()
+                    .timestamp
             )
             team.save()
 
@@ -256,7 +259,7 @@ class FlagSubmitView(APIView):
 
     def post(self, request):
         if not config.get("enable_flag_submission") or (
-            not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
+                not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
         ):
             return FormattedResponse(m="flag_submission_disabled", status=HTTP_403_FORBIDDEN)
 
@@ -339,7 +342,7 @@ class FlagCheckView(APIView):
 
     def post(self, request):
         if not config.get("enable_flag_submission") or (
-            not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
+                not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
         ):
             return FormattedResponse(m="flag_submission_disabled", status=HTTP_403_FORBIDDEN)
         team = Team.objects.get(id=request.user.team.id)

--- a/src/challenge/views.py
+++ b/src/challenge/views.py
@@ -84,7 +84,7 @@ class CategoryViewset(AdminCreateModelViewSet):
                     output_field=models.BooleanField(),
                 )
             )
-                .prefetch_related(
+            .prefetch_related(
                 Prefetch(
                     "hint_set",
                     queryset=Hint.objects.annotate(
@@ -106,7 +106,7 @@ class CategoryViewset(AdminCreateModelViewSet):
                 ),
                 "hint_set__uses",
             )
-                .select_related("first_blood")
+            .select_related("first_blood")
         )
         if self.request.user.is_staff:
             categories = Category.objects
@@ -117,7 +117,12 @@ class CategoryViewset(AdminCreateModelViewSet):
 
     def list(self, request, *args, **kwargs):
         cache = caches["default"]
-        if config.get("enable_caching") and config.get("start_time") + 15 > time.time() and "preevent_cache" in cache:
+        if (
+            config.get("enable_preevent_cache")
+            and config.get("start_time") + 15 > time.time()
+            and "preevent_cache" in cache
+            and not request.user.is_staff
+        ):
             return FormattedResponse(cache.get("preevent_cache"))
 
         categories = cache.get(get_cache_key(request.user))
@@ -165,27 +170,27 @@ class ScoresViewset(ModelViewSet):
         if user:
             user = get_object_or_404(get_user_model(), id=user)
             user.leaderboard_points = (
-                    Score.objects.filter(user=user, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
+                Score.objects.filter(user=user, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
             )
             user.points = Score.objects.filter(user=user).aggregate(Sum("points"))["points__sum"] or 0
             user.last_score = (
                 Score.objects.filter(user=user, leaderboard=True, tiebreaker=True)
-                    .order_by("timestamp")
-                    .first()
-                    .timestamp
+                .order_by("timestamp")
+                .first()
+                .timestamp
             )
             user.save()
         if team:
             team = get_object_or_404(Team, id=team)
             team.leaderboard_points = (
-                    Score.objects.filter(team=team, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
+                Score.objects.filter(team=team, leaderboard=True).aggregate(Sum("points"))["points__sum"] or 0
             )
             team.points = Score.objects.filter(team=team).aggregate(Sum("points"))["points__sum"] or 0
             team.last_score = (
                 Score.objects.filter(team=team, leaderboard=True, tiebreaker=True)
-                    .order_by("timestamp")
-                    .first()
-                    .timestamp
+                .order_by("timestamp")
+                .first()
+                .timestamp
             )
             team.save()
 
@@ -259,7 +264,7 @@ class FlagSubmitView(APIView):
 
     def post(self, request):
         if not config.get("enable_flag_submission") or (
-                not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
+            not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
         ):
             return FormattedResponse(m="flag_submission_disabled", status=HTTP_403_FORBIDDEN)
 
@@ -342,7 +347,7 @@ class FlagCheckView(APIView):
 
     def post(self, request):
         if not config.get("enable_flag_submission") or (
-                not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
+            not config.get("enable_flag_submission_after_competition") and time.time() > config.get("end_time")
         ):
             return FormattedResponse(m="flag_submission_disabled", status=HTTP_403_FORBIDDEN)
         team = Team.objects.get(id=request.user.team.id)

--- a/src/ractf/management/commands/create_preevent_cache.py
+++ b/src/ractf/management/commands/create_preevent_cache.py
@@ -1,0 +1,93 @@
+import time
+
+from django.core.cache import caches
+from django.core.management import BaseCommand
+from django.db import models
+from django.db.models import When, Case, Value, Prefetch
+from django.http import HttpRequest
+from django.utils import timezone
+from rest_framework.request import Request
+
+from challenge import serializers
+from challenge.models import Challenge, File, Tag, Category
+from challenge.serializers import FastCategorySerializer
+from challenge.sql import get_solve_counts, get_positive_votes, get_negative_votes
+from config import config
+from hint.models import Hint
+
+
+def get_queryset():
+    challenges = (
+        Challenge.objects.annotate(
+            unlock_time_surpassed=Case(
+                When(release_time__lte=timezone.now(), then=Value(True)),
+                default=Value(False),
+                output_field=models.BooleanField(),
+            )
+        )
+        .prefetch_related(
+            Prefetch(
+                "hint_set",
+                queryset=Hint.objects.annotate(
+                    used=Value(False)
+                ),
+                to_attr="hints",
+            ),
+            Prefetch("file_set", queryset=File.objects.all(), to_attr="files"),
+            Prefetch(
+                "tag_set",
+                queryset=Tag.objects.all()
+                if time.time() > config.get("end_time")
+                else Tag.objects.filter(post_competition=False),
+                to_attr="tags",
+            ),
+        )
+        .select_related("first_blood")
+    )
+    categories = Category.objects.filter(release_time__lte=timezone.now())
+    qs = categories.prefetch_related(Prefetch("category_challenges", queryset=challenges, to_attr="challenges"))
+    return qs
+
+
+def setup_context(context):
+    context.update(
+        {
+            "request": Request(HttpRequest()),
+            "solve_counter": get_solve_counts(),
+            "votes_positive_counter": get_positive_votes(),
+            "votes_negative_counter": get_negative_votes(),
+            "solves": []
+        }
+    )
+
+
+def is_solved(challenge, *args, **kwargs):
+    return False
+
+
+def is_unlocked(challenge, *args, **kwargs):
+    return challenge.unlock_requirements == ""
+
+
+class Command(BaseCommand):
+    help = "Creates a cache to lessen the impact of the first 15 seconds of request spam"
+
+    def handle(self, *args, **options):
+        categories = get_queryset()
+        solve_counts = get_solve_counts()
+        positive_votes = get_positive_votes()
+        negative_votes = get_negative_votes()
+        Challenge.is_unlocked = is_unlocked
+        Challenge.is_solved = is_solved
+        serializers.setup_context = setup_context
+
+        categories = FastCategorySerializer(categories, many=True, context={}).data
+        for category in categories:
+            for challenge in category["challenges"]:
+                challenge["votes"] = {
+                    "positive": positive_votes.get(challenge["id"], 0),
+                    "negative": negative_votes.get(challenge["id"], 0),
+                }
+                challenge["solve_count"] = solve_counts.get(challenge["id"], 0)
+        caches["default"].set("preevent_cache", categories, timeout=None)
+        print(categories)

--- a/src/ractf/management/commands/create_preevent_cache.py
+++ b/src/ractf/management/commands/create_preevent_cache.py
@@ -3,15 +3,15 @@ import time
 from django.core.cache import caches
 from django.core.management import BaseCommand
 from django.db import models
-from django.db.models import When, Case, Value, Prefetch
+from django.db.models import Case, Prefetch, Value, When
 from django.http import HttpRequest
 from django.utils import timezone
 from rest_framework.request import Request
 
 from challenge import serializers
-from challenge.models import Challenge, File, Tag, Category
+from challenge.models import Category, Challenge, File, Tag
 from challenge.serializers import FastCategorySerializer
-from challenge.sql import get_solve_counts, get_positive_votes, get_negative_votes
+from challenge.sql import get_negative_votes, get_positive_votes, get_solve_counts
 from config import config
 from hint.models import Hint
 
@@ -28,9 +28,7 @@ def get_queryset():
         .prefetch_related(
             Prefetch(
                 "hint_set",
-                queryset=Hint.objects.annotate(
-                    used=Value(False)
-                ),
+                queryset=Hint.objects.annotate(used=Value(False)),
                 to_attr="hints",
             ),
             Prefetch("file_set", queryset=File.objects.all(), to_attr="files"),
@@ -56,7 +54,7 @@ def setup_context(context):
             "solve_counter": get_solve_counts(),
             "votes_positive_counter": get_positive_votes(),
             "votes_negative_counter": get_negative_votes(),
-            "solves": []
+            "solves": [],
         }
     )
 

--- a/src/sockets/signals.py
+++ b/src/sockets/signals.py
@@ -101,5 +101,7 @@ def on_announcement_create(sender, instance, **kwargs):
 
 
 @receiver(post_save, sender=Challenge)
-def on_challenge_edit(sender, instance, **kwargs):
+def on_challenge_edit(sender, instance, update_fields, **kwargs):
+    if update_fields is not None and "first_blood" in update_fields:
+        return
     broadcast({"type": "send_json", "event_code": 6, "challenge_id": instance.id})


### PR DESCRIPTION
Some more caching and optimisations to lighten the load of the first few minutes of the ctf.
todo:
- [x] Cache initial response for all teams for 15-30 seconds
- [ ] Send partial challenge updates so shell doesnt request /challenge/categories