### PR TITLE
Fix long user agents not being able to hit member self

### DIFF
--- a/src/member/models.py
+++ b/src/member/models.py
@@ -83,7 +83,7 @@ class UserIP(ExportModelOperationsMixin("user_ip"), models.Model):
         if not request.user.is_authenticated:
             return
         ip = request.headers.get("x-forwarded-for", "0.0.0.0")
-        user_agent = request.headers.get("user-agent", "???")
+        user_agent = request.headers.get("user-agent", "???")[:255]
         qs = UserIP.objects.filter(user=request.user, ip=ip)
         if qs.exists():
             user_ip = qs.first()


### PR DESCRIPTION
This could also be fixed by making the max column length longer, I think this is a better solution because we'd end up having this caused by one exceptionally long user agent anyway.