### PR TITLE
Hide cserv_name from challenge_metadata on locked challenges

### DIFF
--- a/src/challenge/serializers.py
+++ b/src/challenge/serializers.py
@@ -119,7 +119,9 @@ class FastLockedChallengeSerializer(ChallengeSerializerMixin, serpy.Serializer):
     unlock_time_surpassed = serpy.MethodField()
 
     def serialize(self, instance):
-        return self._serialize(instance, self._compiled_fields)
+        serialized = self._serialize(instance, self._compiled_fields)
+        serialized["challenge_metadata"].pop("cserv_name", None)
+        return serialized
 
 
 class FastChallengeSerializer(ChallengeSerializerMixin, serpy.Serializer):


### PR DESCRIPTION
Users can request instances of challenges that are locked through the andromeda api, thats a wontfix, but this hides the info so its basically impossible to do that now.