### PR TITLE
Invalidate challenge cache on hint file and tag changes

### DIFF
--- a/src/challenge/signals.py
+++ b/src/challenge/signals.py
@@ -2,11 +2,15 @@ from django.core.cache import caches
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from challenge.models import Category, Challenge
+from challenge.models import Category, Challenge, File, Tag
+from hint.models import Hint
 
 
 @receiver([post_save, post_delete], sender=Challenge)
 @receiver([post_save, post_delete], sender=Category)
+@receiver([post_save, post_delete], sender=Hint)
+@receiver([post_save, post_delete], sender=File)
+@receiver([post_save, post_delete], sender=Tag)
 def challenge_cache_invalidate(sender, instance, **kwargs):
     new_index = caches["default"].get("challenge_mod_index", 0) + 1
     caches["default"].set("challenge_mod_index", new_index, timeout=None)

--- a/src/challenge/signals.py
+++ b/src/challenge/signals.py
@@ -3,7 +3,8 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from challenge.models import Category, Challenge, File, Tag
-from hint.models import Hint
+from challenge.views import get_cache_key
+from hint.models import Hint, HintUse
 
 
 @receiver([post_save, post_delete], sender=Challenge)
@@ -14,3 +15,8 @@ from hint.models import Hint
 def challenge_cache_invalidate(sender, instance, **kwargs):
     new_index = caches["default"].get("challenge_mod_index", 0) + 1
     caches["default"].set("challenge_mod_index", new_index, timeout=None)
+
+
+@receiver([post_save, post_delete], sender=HintUse)
+def team_cache_invalidate(sender, instance: HintUse, **kwargs):
+    caches["default"].delete(get_cache_key(instance.user))


### PR DESCRIPTION
This should (hopefully) be the last challenge cache fix