### PR TITLE
Prometheus statistics improvements & additions.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,27 @@
 version: "3"
 
-services:
+x-gunicorn-master: &x-gunicorn-master
+  build: .
+  entrypoint: 
+  volumes:
+    - .:/app
+  environment:
+    - DOMAIN=localhost
+    - FRONTEND_URL=http://localhost:8000/
+    - SECRET_KEY=CorrectHorseBatteryStaple
+    - DJANGO_SETTINGS_MODULE=backend.settings.local
+    - ANDROMEDA_IP=andromeda
+    - ANDROMEDA_URL=http://andromeda:6000
+    - REDIS_PORT=6379
+    - REDIS_HOST=redis
+    - REDIS_CONFIG_DB=3
+    - REDIS_CACHE_DB=10
+    - SQL_PORT=5432
+    - SQL_HOST=database
+    - SQL_USER=postgres
+    - SQL_DATABASE=postgres
 
+services:
   redis:
     image: docker.io/redis:5
 
@@ -27,41 +47,19 @@ services:
     command:
       caddy run --config /etc/caddy/Caddyfile.development --adapter caddyfile
 
-  backend: &backend
-    build: .
+  backend:
+    <<: *x-gunicorn-master
     entrypoint: /app/entrypoints/backend.sh
-    command: python src/manage.py runserver 0.0.0.0:8000
-    volumes:
-      - .:/app
-    environment:
-      - DOMAIN=localhost
-      - FRONTEND_URL=http://localhost:8000/
-      - SECRET_KEY=CorrectHorseBatteryStaple
-      - DJANGO_SETTINGS_MODULE=backend.settings.local
-
-      - ANDROMEDA_IP=andromeda
-      - ANDROMEDA_URL=http://andromeda:6000
-
-      - REDIS_PORT=6379
-      - REDIS_HOST=redis
-      - REDIS_CONFIG_DB=3
-      - REDIS_CACHE_DB=10
-
-      - SQL_PORT=5432
-      - SQL_HOST=database
-      - SQL_USER=postgres
-      - SQL_DATABASE=postgres
-
+    command: gunicorn backend.wsgi:application
     depends_on:
       - database
 
   sockets:
-    <<: *backend
+    <<: *x-gunicorn-master
     entrypoint: /app/entrypoints/sockets.sh
-    command: gunicorn -w 12 -b 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker backend.asgi:application
+    command: gunicorn backend.asgi:application
     depends_on:
       - backend
-    working_dir: /app/src/
 
   watchtower:
     image: docker.io/containrrr/watchtower

--- a/entrypoints/backend.sh
+++ b/entrypoints/backend.sh
@@ -1,5 +1,4 @@
-#! /bin/sh
-
+#!/usr/bin/env sh
 
 if [ -z "$prometheus_multiproc_dir" ]
 then
@@ -9,18 +8,16 @@ else
   rm $prometheus_multiproc_dir/* -rf
 fi
 
-stdbuf -o 0 echo -n "Waiting for postgres... "
+echo "Waiting for postgres... "
 while ! nc -z $SQL_HOST $SQL_PORT
 do
   sleep 0.69
 done
 echo "Done."
 
-
 echo "Running migrations..."
 /app/src/manage.py migrate
 echo "Done."
-
 
 if [ "$LOAD_FIXTURES" ]
 then
@@ -28,10 +25,10 @@ then
   /app/src/manage.py loaddata test_fixtures
 fi
 
-
+export GUNICORN_CMD_ARGS="--chdir=/app/src/ --reload --workers=4 --bind=0.0.0.0:8000 --worker-class=gthread"
 if [ -f /etc/newrelic.ini ]
 then
   NEW_RELIC_CONFIG_FILE=/etc/newrelic.ini newrelic-admin run-program "$@"
 else
-  exec "$@"
+  exec $@
 fi

--- a/entrypoints/sockets.sh
+++ b/entrypoints/sockets.sh
@@ -1,24 +1,23 @@
-#! /bin/bash
+#!/usr/bin/env sh
 
-echo -n "Waiting for postgres... "
+echo "Waiting for postgres... "
 while ! nc -z $SQL_HOST $SQL_PORT
 do
   sleep 0.69
 done
 echo "Done."
 
-
-echo -n "Waiting for django... "
+echo "Waiting for django... "
 while ! nc -z backend 8000
 do
   sleep 0.69
 done
 echo "Done."
 
-
+export GUNICORN_CMD_ARGS="--chdir=/app/src/ --reload --workers=4 --bind=0.0.0.0:8000 --worker-class=uvicorn.workers.UvicornWorker"
 if [ -f /etc/newrelic.ini ]
 then
   NEW_RELIC_CONFIG_FILE=/etc/newrelic.ini newrelic-admin run-program "$@"
 else
-  exec "$@"
+  exec $@
 fi

--- a/src/stats/apps.py
+++ b/src/stats/apps.py
@@ -3,7 +3,6 @@ from importlib import import_module
 
 from django.apps import AppConfig
 
-import challenge
 import member
 import team
 
@@ -20,9 +19,7 @@ class StatsConfig(AppConfig):
 
         signals = import_module("stats.signals", "stats")
 
-        Team, Solve, Member = team.models.Team, challenge.models.Solve, member.models.Member
+        Team, Member = team.models.Team, member.models.Member
 
         signals.team_count.set(Team.objects.count())
-        signals.solve_count.set(Solve.objects.count())
         signals.member_count.set(Member.objects.count())
-        signals.correct_solve_count.set(Solve.objects.filter(correct=True).count())

--- a/src/stats/signals.py
+++ b/src/stats/signals.py
@@ -1,7 +1,7 @@
 from django.core.cache import cache
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from prometheus_client import Gauge
+from prometheus_client import Counter, Gauge
 
 from backend.signals import (
     flag_score,
@@ -10,16 +10,27 @@ from backend.signals import (
     websocket_connect,
     websocket_disconnect,
 )
-from challenge.models import Solve
+from challenge.models import Challenge, Solve
 from member.models import Member
 from team.models import Team
 
 member_count = Gauge("member_count", "The number of members currently registered")
 team_count = Gauge("team_count", "The number of teams currently registered")
-solve_count = Gauge("solve_count", "The count of both correct and incorrect solves")
-correct_solve_count = Gauge("correct_solve_count", "The count of correct solves")
+attempts_total = Counter(
+    "attempts_total",
+    "Incorrect solves by challenge and category",
+    labelnames=('challenge', 'category',),
+)
+solves_total = Counter(
+    "solves_total",
+    "Correct solves by challenge and category",
+    labelnames=('challenge', 'category',),
+)
+points_total = Counter('points_total', "Total points scored")
 connected_websocket_users = Gauge(
-    "connected_websocket_users", "The number of users connected to the websocket", multiprocess_mode="livesum"
+    "connected_websocket_users",
+    "The number of users connected to the websocket",
+    multiprocess_mode="livesum",
 )
 
 if not cache.get("migrations_needed"):
@@ -28,12 +39,6 @@ if not cache.get("migrations_needed"):
 
     cache.set("team_count", Team.objects.count(), timeout=None)
     team_count.set(cache.get("team_count"))
-
-    cache.set("solve_count", Solve.objects.count(), timeout=None)
-    solve_count.set(cache.get("solve_count"))
-
-    cache.set("correct_solve_count", Solve.objects.filter(correct=True).count(), timeout=None)
-    correct_solve_count.set(cache.get("correct_solve_count"))
 
 
 @receiver(register)
@@ -57,17 +62,35 @@ def on_team_delete(sender, instance, **kwargs):
 
 
 @receiver(flag_score)
-def on_solve_create(sender, user, team, challenge, flag, solve, **kwargs):
-    cache.set("solve_count", cache.get("solve_count") + 1, timeout=None)
+def on_solve_create(
+    sender,
+    user,
+    team,
+    challenge: Challenge,
+    flag,
+    solve: Solve,
+    **kwargs,
+) -> None:
+    """Update challenge solve metrics."""
+
+    labelset = dict(challenge=challenge.name, category=challenge.category.name)
     if solve.correct:
-        cache.set("correct_solve_count", cache.get("correct_solve_count") + 1, timeout=None)
+        solves_total.labels(**labelset).inc()
+        points_total.inc(challenge.score)
+    else:
+        attempts_total.labels(**labelset).inc()
 
 
 @receiver(post_delete, sender=Solve)
 def on_solve_delete(sender, instance, **kwargs):
-    cache.set("solve_count", cache.get("solve_count") - 1, timeout=None)
-    if instance.correct:
-        cache.set("correct_solve_count", cache.get("correct_solve_count") - 1, timeout=None)
+    # According to Dave, it does not make sense to delete a solve.
+    # According to Joe, it does make sense in case someone breaks something.
+
+    # We do not update the solve metrics here, as we use counters to
+    # work around multiprocessing issues due to Python's limitation
+    # of running on a single core. This also applies to the `points_total`
+    # metric, which is not updated here either.
+    pass
 
 
 @receiver(websocket_connect)

--- a/src/stats/views.py
+++ b/src/stats/views.py
@@ -14,7 +14,7 @@ from challenge.models import Score
 from challenge.sql import get_incorrect_solve_counts, get_solve_counts
 from config import config
 from member.models import UserIP
-from stats.signals import correct_solve_count, member_count, solve_count, team_count
+from stats.signals import member_count, team_count
 from team.models import Team
 
 
@@ -96,10 +96,14 @@ def version(request):
 class PrometheusMetricsView(APIView):
     permission_classes = [IsAdminUser]
 
-    def get(self, request, format=None):
+    def populate_metrics(self) -> None:
+        """Populate Prometheus metrics from the cache or the database."""
+
         member_count.set(cache.get("member_count"))
         team_count.set(cache.get("team_count"))
-        solve_count.set(cache.get("solve_count"))
-        correct_solve_count.set(cache.get("correct_solve_count"))
 
+    def get(self, request, format=None):
+        """Repoulate Prometheus metrics from cache and export statistics."""
+
+        self.populate_metrics()
         return ExportToDjangoView(request)


### PR DESCRIPTION
This makes changes to the existing solve and attempt count metrics to add
labels. This will likely break existing monitoring dashboards, but allows us to
be more granular in the solves (correct flag submissions) and attempts
(incorrect flag submissions) by challenge and category, whilst still allowing to
sum the total amount of flags via PromQL.

Caching of the values is removed. The values are moved to counters, which work
sanely in multiprocess mode in contrast to gauge mode. What we trade off for
this is the ability to decrease solve count, but after development discussions,
we have concluded that we currently do not really care about this use case.

A new metric for the total amount of points scored is introduced. As with the
updated metrics above, this is a counter. This does not allow us to directly run
queries such as retrieving the total amount of points at the end of the event -
we can use the database for that - instead, it will allow us to gather the
point increase in a given point of time, possibly over an entire event if the
range vector time selector is long enough (for instance
`increase(points_total[$__interval])` in a grafana dashboard).

Fixes #183.