### PR TITLE
Handle duplicate bot usernames with an error message instead of a 500

### DIFF
--- a/src/authentication/tests.py
+++ b/src/authentication/tests.py
@@ -918,3 +918,25 @@ class CreateBotUserTestCase(APITestCase):
             },
         )
         self.assertTrue("token" in response.data["d"])
+
+    def test_duplicate_username(self):
+        self.client.force_authenticate(self.user)
+        self.client.post(
+            reverse("create-bot"),
+            data={
+                "username": "bottest",
+                "is_visible": False,
+                "is_staff": True,
+                "is_superuser": True,
+            },
+        )
+        response = self.client.post(
+            reverse("create-bot"),
+            data={
+                "username": "bottest",
+                "is_visible": False,
+                "is_staff": True,
+                "is_superuser": True,
+            },
+        )
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)

--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -5,7 +5,7 @@ import string
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.validators import EmailValidator
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
 from django_filters.rest_framework import DjangoFilterBackend
@@ -361,7 +361,11 @@ class CreateBotView(APIView):
             is_bot=True,
             email=serializer.data["username"] + "@bot.ractf",
         )
-        bot.save()
+
+        try:
+            bot.save()
+        except IntegrityError:
+            return FormattedResponse(m="username_already_exists", status=HTTP_400_BAD_REQUEST)
         return FormattedResponse(d={"token": bot.issue_token()}, status=HTTP_201_CREATED)
 
 


### PR DESCRIPTION
Fixes #194 