### PR TITLE
Improve Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3"
 
 x-gunicorn-master: &x-gunicorn-master
   build: .
-  entrypoint: 
+  entrypoint:
+  privileged: true
   volumes:
     - .:/app
   environment:
@@ -32,7 +33,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
 
   shell:
-    image: index.docker.io/ractf/shell:latest
+    image: ghcr.io/ractf/shell:latest
     ports:
       - "8000:8000"
     environment:
@@ -60,10 +61,3 @@ services:
     command: gunicorn backend.asgi:application
     depends_on:
       - backend
-
-  watchtower:
-    image: docker.io/containrrr/watchtower
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /root/.docker/config.json:/config.json
-    command: --interval 5


### PR DESCRIPTION
* Remove Watchtower
* Swap to GHCR
* Make sure the container is privileged for volumes

Arguably, we should make it clearer that `docker-compose.yml` is for development only. Open to suggestions on how we do that.