### PR TITLE
Add a lot more pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -8,6 +8,20 @@ repos:
         args: [--fix=lf]
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-json
+      - id: check-yaml
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: detect-private-key
+      - id: no-commit-to-branch
+      - id: pretty-format-json
+        args: [--autofix]
 
   - repo: local
     hooks:


### PR DESCRIPTION
Justifications:
* check-added-large-files
  * The `src` directory is currently 2mb, if you're committing something bigger than 500kb something is wrong
* check-executables-have-shebangs/check-shebang-scripts-are-executable
  * This has caught us out before and it's not something we test in CI
* no-commit-to-branch
  * Don't let you commit to default branch then find out you can't push
* detect-aws-credentials/detect-private-key
  * Could happen if testing things like Boto3

It might be worth running these checks in CI for the benefit of Windows users