### PR TITLE
Add Integration Tests

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -17,7 +17,7 @@ jobs:
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"
 
       - name: Start Upstream Container
-        run: docker-compose up -d
+        run: make dev-server
 
       - name: Wait for Upstream to Boot
         run: sleep 10
@@ -34,14 +34,20 @@ jobs:
       - name: Swap to Current branch
         run: "sed -i 's/image: ghcr.io\\/ractf\\/core:latest/build: \\./' docker-compose.yml"
 
+      - name: Confirm Current Docker Compose
+        run: cat docker-compose.yml
+
       - name: Start Current Container
-        run: docker-compose up -d
+        run: make dev-server
 
       - name: Wait for Current to Boot
         run: sleep 10
 
       - name: Confirm Current is Healthy
         run: curl -v --fail localhost:8000/api/v2/stats/stats/
+
+      - name: Clean Up Docker Compose
+        run: make clean-dev-server
 
       - name: Get Core Logs
         run: docker-compose logs backend

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker-compose exec backend make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
+        run: docker-compose exec -w /app backend make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,0 +1,49 @@
+name: Run Integration Tests
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Disable Container Mount
+        run: cat docker-compose.yml | tr '\n' '\r' | sed -e 's/  volumes:\r    - .:\/app//' | tr '\r' '\n' > docker-compose.yml
+
+      - name: Set Docker-Compose to Upstream
+        run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"
+
+      - name: Start Upstream Container
+        run: docker-compose up -d
+
+      - name: Wait for Upstream to Boot
+        run: sleep 10
+
+      - name: Confirm Upstream is Healthy
+        run: curl localhost:8000/api/v2/stats/stats/
+
+      - name: Shut Down Upstream
+        run: docker-compose rm -sf
+
+      - name: Swap to Current branch
+        run: "sed -i 's/image: ghcr.io\\/ractf\\/core:latest/build: \\./' docker-compose.yml"
+
+      - name: Start Current Container
+        run: docker-compose up -d
+
+      - name: Wait for Current to Boot
+        run: sleep 10
+
+      - name: Confirm Current is Healthy
+        run: curl localhost:8000/api/v2/stats/stats/
+
+      - name: Get Core Logs
+        run: docker-compose logs backend
+        if: always()
+
+      - name: Get Sockets Logs
+        run: docker-compose logs sockets
+        if: always()

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
+        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/working_dir:\\/app\\src\\///' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -3,7 +3,7 @@ name: Run Integration Tests
 on: push
 
 jobs:
-  test:
+  integrate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -26,7 +26,7 @@ jobs:
         run: docker exec -w /app --tty $(docker-compose ps -q backend) make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
 
       - name: Confirm Upstream is Healthy
-        run: curl --fail localhost:8000/api/v2/stats/stats/
+        run: curl -v --fail localhost:8000/api/v2/stats/stats/
 
       - name: Shut Down Upstream
         run: docker-compose rm -sf
@@ -41,7 +41,7 @@ jobs:
         run: sleep 10
 
       - name: Confirm Current is Healthy
-        run: curl --fail localhost:8000/api/v2/stats/stats/
+        run: curl -v --fail localhost:8000/api/v2/stats/stats/
 
       - name: Get Core Logs
         run: docker-compose logs backend

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -20,7 +20,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Wait for Upstream to Boot
-        run: sleep 20
+        run: sleep 10
 
       - name: Generate Test Fixtures
         run: docker-compose exec backend 'make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"'
@@ -38,7 +38,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Wait for Current to Boot
-        run: sleep 20
+        run: sleep 10
 
       - name: Confirm Current is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker exec -w /app --tty $(docker-compose ps -q backend) make fake-bulk-data
+        run: docker exec -w /app --tty $(docker-compose ps -q backend) make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Wait for Upstream to Boot
         run: sleep 10
 
+      - name: Generate Test Fixtures
+        run: docker-compose exec backend 'make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"'
+
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/  working_dir: \\/app\\src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
+        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/  working_dir: \\/app\\/src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: cat docker-compose.yml | tr '\n' '\r' | sed -e 's/  volumes:\r    - .:\/app//' | tr '\r' '\n' > docker-compose.yml
+        run: cat docker-compose.yml | tr '\n' '\r' | sed -e 's/  volumes:\r    - .:\/app//' | tr '\r' '\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -20,7 +20,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Wait for Upstream to Boot
-        run: sleep 10
+        run: sleep 20
 
       - name: Generate Test Fixtures
         run: docker-compose exec backend 'make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"'
@@ -38,7 +38,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Wait for Current to Boot
-        run: sleep 10
+        run: sleep 20
 
       - name: Confirm Current is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: cat docker-compose.yml | tr '\n' '\r' | sed -e 's/  volumes:\r    - .:\/app//' | tr '\r' '\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}
+        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker-compose exec -w /app backend make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
+        run: docker-compose exec -w /app backend make fake-bulk-data
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: cat docker-compose.yml | tr '\n' '\r' | sed -e 's/  volumes:\r    - .:\/app//' | tr '\r' '\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}
+        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/working_dir: \\/app\/src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/working_dir: \\/app\/src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
+        run: cat docker-compose.yml | tr '\n' '\r' | sed -e 's/  volumes:\r    - .:\/app//' | tr '\r' '\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/working_dir:\\/app\\src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
+        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/  working_dir: \\/app\\src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker-compose exec backend 'make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"'
+        run: docker-compose exec backend -T 'make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"'
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Confirm Upstream is Healthy
-        run: curl localhost:8000/api/v2/stats/stats/
+        run: curl --fail localhost:8000/api/v2/stats/stats/
 
       - name: Shut Down Upstream
         run: docker-compose rm -sf
@@ -38,7 +38,7 @@ jobs:
         run: sleep 10
 
       - name: Confirm Current is Healthy
-        run: curl localhost:8000/api/v2/stats/stats/
+        run: curl --fail localhost:8000/api/v2/stats/stats/
 
       - name: Get Core Logs
         run: docker-compose logs backend

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disable Container Mount
-        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/working_dir:\\/app\\src\\///' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
+        run: "cat docker-compose.yml | tr '\\n' '\\r' | sed -e 's/  volumes:\\r    - .:\\/app/working_dir:\\/app\\src\\//' | tr '\\r' '\\n' | tee docker-compose.yml.new && mv docker-compose.yml{.new,}"
 
       - name: Set Docker-Compose to Upstream
         run: "sed -i 's/build: \\./image: ghcr.io\\/ractf\\/core:latest/' docker-compose.yml"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,9 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker-compose exec -w /app backend make fake-bulk-data
-        env:
-          COMPOSE_INTERACTIVE_NO_CLI: "1"
+        run: docker exec -w /app --tty $(docker-compose ps -q backend) make fake-bulk-data
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker-compose exec backend -T 'make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"'
+        run: docker-compose exec backend make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Generate Test Fixtures
         run: docker-compose exec -w /app backend make fake-bulk-data
+        env:
+          COMPOSE_INTERACTIVE_NO_CLI: "1"
 
       - name: Confirm Upstream is Healthy
         run: curl --fail localhost:8000/api/v2/stats/stats/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Unit Tests
 
 on: push
 

--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,5 @@ clean-test:
 	rm -rf /tmp/ractf-linting.cache /tmp/ractf-linting.db .testmondata
 
 clean-dev-server:
-	docker-compose rm -sf
+	docker-compose rm -sfv
+	docker volume rm -f core_postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 
 x-gunicorn-master: &x-gunicorn-master
   build: .
-  entrypoint:
   privileged: true
   volumes:
     - .:/app
@@ -32,6 +31,8 @@ services:
     environment:
       - POSTGRES_EXTENSIONS=citext
       - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      - 'postgres:/var/lib/postgresql/data/'
 
   shell:
     image: ghcr.io/ractf/shell:latest
@@ -62,3 +63,6 @@ services:
     command: gunicorn backend.asgi:application
     depends_on:
       - backend
+
+volumes:
+  postgres: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,14 +53,14 @@ services:
   backend:
     <<: *x-gunicorn-master
     entrypoint: /app/entrypoints/backend.sh
-    command: gunicorn backend.wsgi:application
+    command: gunicorn backend.wsgi:application -b 0.0.0.0:8000
     depends_on:
       - database
 
   sockets:
     <<: *x-gunicorn-master
     entrypoint: /app/entrypoints/sockets.sh
-    command: gunicorn backend.asgi:application
+    command: gunicorn backend.asgi:application -b 0.0.0.0:8000
     depends_on:
       - backend
 


### PR DESCRIPTION
This Pull Request adds integrations tests in GitHub Actions, which perform the following:
- Boot up backend using the image from GitHub Container Registry
- Wait 10 seconds for the boot
- Use `make fake-data` to generate some test fixtures
- Shut down the containers
- Boot up the containers on the current branch
- Wait 10 seconds for the boot
- Confirm that the `/stats/stats/` endpoint works

To do this, I've had to add a persistent database to the `postgres` container, but I've updated the `clean-dev-server` makefile target to clean this up. This is tested within the workflow.

This should hopefully catch things like us writing broken migrations or updating things like twisted which prevent core from booting.

Resolves #238 