### PR TITLE
Remove unnecessary setting causing a warning

### DIFF
--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -219,7 +219,6 @@ AUTHENTICATION_BACKENDS = ["backend.backends.EmailOrUsernameBackend"]
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 


### PR DESCRIPTION
This was changed to default to true in django 4.0 and throws a warning.