### PR TITLE
Rely on database unique constraints

### DIFF
--- a/src/authentication/basic_auth.py
+++ b/src/authentication/basic_auth.py
@@ -16,7 +16,6 @@ class BasicAuthRegistrationProvider(RegistrationProvider):
             raise ValidationError("A required field was not found.")
 
         self.validate_email(data["email"])
-        self.check_email_or_username_in_use(email=data["email"], username=data["username"])
         if len(data["username"]) > 36:
             raise ValidationError("username_too_long")
 

--- a/src/authentication/providers.py
+++ b/src/authentication/providers.py
@@ -30,10 +30,6 @@ class RegistrationProvider(Provider, abc.ABC):  # pragma: no cover
         email_validator = EmailValidator()
         email_validator(email)
 
-    def check_email_or_username_in_use(self, email=None, username=None):
-        if get_user_model().objects.filter(username__iexact=username) or get_user_model().objects.filter(email=email):
-            raise ValidationError("email_or_username_in_use")
-
 
 class LoginProvider(Provider, abc.ABC):  # pragma: no cover
     type = "login"

--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -87,6 +87,14 @@ class RegistrationView(CreateAPIView):
     def dispatch(self, *args, **kwargs):
         return super(RegistrationView, self).dispatch(*args, **kwargs)
 
+    def create(self, request, *args, **kwargs):
+        try:
+            return super().create(request, *args, **kwargs)
+        except IntegrityError:
+            # If we need granularity to see whether email or username is in used here,
+            # check the constraint name that is returned.
+            return FormattedResponse(m="email_or_username_in_use", status=HTTP_400_BAD_REQUEST)
+
 
 class LogoutView(APIView):
     permission_classes = (permissions.IsAuthenticated & ~IsBot,)


### PR DESCRIPTION
PR #245 updated the validators to check for duplicate usernames and
emails by running a query before posting the data. Let's rely on the
database indexes instead, which is more robust. This builds on top of
PR #245's tests to verify the functionality.