### PR TITLE
Keep emails enabled when envvar missing

### DIFF
--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -375,7 +375,7 @@ EMAIL_BACKEND = {
     "TEST": "anymail.backends.test.EmailBackend",
     "DISABLED": "django.core.mail.backends.dummy.EmailBackend"
 }[os.getenv("EMAIL_PROVIDER", "DISABLED")]
-EMAIL_ENABLED = bool(os.getenv("EMAIL_PROVIDER", False))
+EMAIL_ENABLED = EMAIL_BACKEND != "DISABLED"
 
 ANYMAIL = {
     "AMAZON_SES_CLIENT_PARAMS": {

--- a/src/backend/settings/lint.py
+++ b/src/backend/settings/lint.py
@@ -3,6 +3,7 @@ from . import *
 SECRET_KEY = "CorrectHorseBatteryStaple"
 
 EMAIL_BACKEND = "anymail.backends.test.EmailBackend"
+EMAIL_ENABLED = False
 
 FRONTEND_URL = "http://example.com/"
 DOMAIN = "example.com"


### PR DESCRIPTION
This was causing issues in environments where the `EMAIL_PROVIDER` environments variable wasn't being set because a settings module was already configuring it.