### PR TITLE
Add a Health Check for Broken Freeform Challenges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ $RECYCLE.BIN/
 *.sqlite3
 *.db
 .vim
+src/publicmedia

--- a/src/admin/tests.py
+++ b/src/admin/tests.py
@@ -88,7 +88,7 @@ class BadFlagConfigTestCase(APITestCase):
         self.client.force_authenticate(user=self.user)
 
         response = self.client.get(reverse("self-check"))
-        self.assertEqual(len(response.data["d"]), 14)
+        self.assertEqual(len(response.data["d"]), 17)
 
 class DevMailEndpointTestCase(TestCase):
     def test_endpoint_absent(self):

--- a/src/challenge/models.py
+++ b/src/challenge/models.py
@@ -72,17 +72,20 @@ class Challenge(ExportModelOperationsMixin("challenge"), models.Model):
         issues = []
 
         if not self.score:
-            issues.append({"issue": "missing_points", "challenge": self.id})
+            issues.append({"issue": "missing_points", "challenge": self.pk})
 
         if not self.flag_type:
-            issues.append({"issue": "missing_flag_type", "challenge": self.id})
+            issues.append({"issue": "missing_flag_type", "challenge": self.pk})
         elif type(self.flag_metadata) != dict:
-            issues.append({"issue": "invalid_flag_data_type", "challenge": self.id})
+            issues.append({"issue": "invalid_flag_data_type", "challenge": self.pk})
         else:
             issues += [
-                {"issue": "invalid_flag_data", "extra": issue, "challenge": self.id}
+                {"issue": "invalid_flag_data", "extra": issue, "challenge": self.pk}
                 for issue in self.flag_plugin.self_check()
             ]
+
+        if (self.flag_type == "lenient") ^ (self.challenge_type == "freeform"):
+            issues.append({"issue": "lenient_freeform_mismatch", "challenge": self.pk})
 
         return issues
 

--- a/src/challenge/tests/test_models.py
+++ b/src/challenge/tests/test_models.py
@@ -21,8 +21,8 @@ class ChallengeTestCase(ChallengeSetupMixin, APITestCase):
             score=1000,
         )
         challenge.save()
-        check = challenge.self_check()
-        self.assertEqual(check[0]["issue"], "missing_flag_type")
+        checks = challenge.self_check()
+        self.assertIn("missing_flag_type", [check["issue"] for check in checks])
 
     def test_invalid_flag_data_type(self):
         challenge = Challenge(
@@ -37,8 +37,72 @@ class ChallengeTestCase(ChallengeSetupMixin, APITestCase):
             score=1000,
         )
         challenge.save()
-        check = challenge.self_check()
-        self.assertEqual(check[0]["issue"], "invalid_flag_data_type")
+        checks = challenge.self_check()
+        self.assertIn("invalid_flag_data_type", [check["issue"] for check in checks])
+
+    def test_not_leiant_or_freeform(self):
+        challenge = Challenge(
+            name="test5",
+            category=self.category,
+            description="a",
+            challenge_type="basic",
+            challenge_metadata={},
+            flag_type="plaintext",
+            flag_metadata={"flag": "ractf{a}", "exclude_passes": []},
+            author="",
+            score=1000,
+        )
+        challenge.save()
+        checks = challenge.self_check()
+        self.assertNotIn("lenient_freeform_mismatch", [check["issue"] for check in checks])
+
+    def test_lenient_without_freeform(self):
+        challenge = Challenge(
+            name="test5",
+            category=self.category,
+            description="a",
+            challenge_type="basic",
+            challenge_metadata={},
+            flag_type="lenient",
+            flag_metadata={"flag": "ractf{a}", "exclude_passes": []},
+            author="",
+            score=1000,
+        )
+        challenge.save()
+        checks = challenge.self_check()
+        self.assertIn("lenient_freeform_mismatch", [check["issue"] for check in checks])
+
+    def test_freeform_without_lenient(self):
+        challenge = Challenge(
+            name="test5",
+            category=self.category,
+            description="a",
+            challenge_type="freeform",
+            challenge_metadata={},
+            flag_type="plaintext",
+            flag_metadata={"flag": "ractf{a}", "exclude_passes": []},
+            author="",
+            score=1000,
+        )
+        challenge.save()
+        checks = challenge.self_check()
+        self.assertIn("lenient_freeform_mismatch", [check["issue"] for check in checks])
+
+    def test_correct_freeform(self):
+        challenge = Challenge(
+            name="test5",
+            category=self.category,
+            description="a",
+            challenge_type="freeform",
+            challenge_metadata={},
+            flag_type="lenient",
+            flag_metadata={"flag": "ractf{a}", "exclude_passes": []},
+            author="",
+            score=1000,
+        )
+        challenge.save()
+        checks = challenge.self_check()
+        self.assertNotIn("lenient_freeform_mismatch", [check["issue"] for check in checks])
 
     def test_is_unlocked_null_user(self):
         self.assertEqual(self.challenge2.is_unlocked(None), False)

--- a/src/challenge/tests/test_models.py
+++ b/src/challenge/tests/test_models.py
@@ -40,7 +40,7 @@ class ChallengeTestCase(ChallengeSetupMixin, APITestCase):
         checks = challenge.self_check()
         self.assertIn("invalid_flag_data_type", [check["issue"] for check in checks])
 
-    def test_not_leiant_or_freeform(self):
+    def test_not_lenient_or_freeform(self):
         challenge = Challenge(
             name="test5",
             category=self.category,


### PR DESCRIPTION
Resolves #191 (not a bug, the error is correct).

This also swaps the existing health check tests to `assertIn` so they don't break as we add more health checks.