### PR TITLE
Move enabling challenge server to settings

### DIFF
--- a/src/andromeda/tests.py
+++ b/src/andromeda/tests.py
@@ -44,3 +44,17 @@ class AndromedaTestCase(TeamSetupMixin, APITestCase):
             with self.assertRaises(ConnectionError):
                 self.client.force_authenticate(user=self.user)
                 self.client.get(reverse("get-instance", args=["1"]))
+
+
+class PolarisTestCase(TeamSetupMixin, APITestCase):
+    def test_get_instance(self):
+        # This is a bad test but we need a stub service
+        with self.settings(
+            CHALLENGE_SERVER_ENABLED=True,
+            POLARIS_URL="http://polaris",
+            POLARIS_USERNAME="polaris",
+            POLARIS_PASSWORD="polaris",
+        ):
+            with self.assertRaises(ConnectionError):
+                self.client.force_authenticate(user=self.user)
+                self.client.get(reverse("get-instance", args=["1"]))

--- a/src/andromeda/tests.py
+++ b/src/andromeda/tests.py
@@ -1,1 +1,46 @@
-# Create your tests here.
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from config import config
+
+from team.tests import TeamSetupMixin
+from requests.exceptions import ConnectionError
+
+
+class AndromedaTestCase(TeamSetupMixin, APITestCase):
+    def test_get_instance_disabled_challenge_server(self):
+        with self.settings(
+            CHALLENGE_SERVER_ENABLED=False,
+        ):
+            self.client.force_authenticate(user=self.user)
+            response = self.client.get(reverse("get-instance", args=["1"]))
+            self.assertContains(response, "challenge_server_disabled", status_code=403)
+
+    def test_request_new_instance_disabled_challenge_server(self):
+        with self.settings(
+            CHALLENGE_SERVER_ENABLED=False,
+        ):
+            self.client.force_authenticate(user=self.user)
+            response = self.client.get(reverse("request-new-instance", args=["1"]))
+            self.assertContains(response, "challenge_server_disabled", status_code=403)
+
+    def test_get_instance_no_team(self):
+        with self.settings(
+            CHALLENGE_SERVER_ENABLED=True,
+        ):
+            self.client.force_authenticate(user=self.user)
+            config.set("enable_team_leave", True)
+            self.client.post(reverse("team-leave"))
+            response = self.client.get(reverse("get-instance", args=["1"]))
+            self.assertContains(response, "challenge_server_team_required", status_code=403)
+
+    def test_get_instance(self):
+        # This is a bad test but we need a stub service
+        with self.settings(
+            CHALLENGE_SERVER_ENABLED=True,
+            ANDROMEDA_URL="http://andromeda",
+            ANDROMEDA_API_KEY="andromeda",
+            ANDROMEDA_TIMEOUT=0.1,
+        ):
+            with self.assertRaises(ConnectionError):
+                self.client.force_authenticate(user=self.user)
+                self.client.get(reverse("get-instance", args=["1"]))

--- a/src/andromeda/tests.py
+++ b/src/andromeda/tests.py
@@ -44,17 +44,3 @@ class AndromedaTestCase(TeamSetupMixin, APITestCase):
             with self.assertRaises(ConnectionError):
                 self.client.force_authenticate(user=self.user)
                 self.client.get(reverse("get-instance", args=["1"]))
-
-
-class PolarisTestCase(TeamSetupMixin, APITestCase):
-    def test_get_instance(self):
-        # This is a bad test but we need a stub service
-        with self.settings(
-            CHALLENGE_SERVER_ENABLED=True,
-            POLARIS_URL="http://polaris",
-            POLARIS_USERNAME="polaris",
-            POLARIS_PASSWORD="polaris",
-        ):
-            with self.assertRaises(ConnectionError):
-                self.client.force_authenticate(user=self.user)
-                self.client.get(reverse("get-instance", args=["1"]))

--- a/src/andromeda/views.py
+++ b/src/andromeda/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.status import HTTP_403_FORBIDDEN
@@ -8,7 +9,6 @@ from andromeda.serializers import JobSubmitSerializer
 from backend.response import FormattedResponse
 from challenge.models import Challenge
 from challenge.permissions import CompetitionOpen
-from config import config
 
 
 class GetInstanceView(APIView):
@@ -16,7 +16,7 @@ class GetInstanceView(APIView):
     throttle_scope = "challenge_instance_get"
 
     def get(self, request, job_id):
-        if not config.get("enable_challenge_server"):
+        if not settings.CHALLENGE_SERVER_ENABLED:
             return FormattedResponse(m="challenge_server_disabled", status=HTTP_403_FORBIDDEN)
         if not request.user.team:
             return FormattedResponse(m="challenge_server_team_required", status=HTTP_403_FORBIDDEN)
@@ -28,7 +28,7 @@ class ResetInstanceView(APIView):
     throttle_scope = "challenge_instance_reset"
 
     def get(self, request, job_id):
-        if not config.get("enable_challenge_server"):
+        if not settings.CHALLENGE_SERVER_ENABLED:
             return FormattedResponse(m="challenge_server_disabled", status=HTTP_403_FORBIDDEN)
         return FormattedResponse(client.request_reset(request.user.team.id, job_id))
 

--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -282,7 +282,7 @@ REST_FRAMEWORK = {
     "NUM_PROXIES": int(os.getenv("NUM_PROXIES", 0)),
 }
 
-if os.getenv("CHALLENGE_SERVER_TYPE") == "POLARIS":
+if os.getenv("CHALLENGE_SERVER_TYPE") == "POLARIS": # pragma: no cover
     CHALLENGE_SERVER_ENABLED = True
     POLARIS_URL = os.getenv("POLARIS_URL")
     POLARIS_USERNAME = os.getenv("POLARIS_USERNAME")

--- a/src/backend/settings/__init__.py
+++ b/src/backend/settings/__init__.py
@@ -57,7 +57,6 @@ DEFAULT_CONFIG = {
     "token_provider": "basic_auth",
     "enable_bot_users": True,
     "enable_caching": True,
-    "enable_challenge_server": True,
     "enable_ctftime": True,
     "enable_flag_submission": True,
     "enable_flag_submission_after_competition": True,
@@ -284,14 +283,18 @@ REST_FRAMEWORK = {
 }
 
 if os.getenv("CHALLENGE_SERVER_TYPE") == "POLARIS":
+    CHALLENGE_SERVER_ENABLED = True
     POLARIS_URL = os.getenv("POLARIS_URL")
     POLARIS_USERNAME = os.getenv("POLARIS_USERNAME")
     POLARIS_PASSWORD = os.getenv("POLARIS_PASSWORD")
-else:
+elif os.getenv("ANDROMEDA_URL") or os.getenv("CHALLENGE_SERVER_TYPE") == "ANDROMEDA": # Backwards compatability with old Docker Compose files
+    CHALLENGE_SERVER_ENABLED = True
     ANDROMEDA_URL = os.getenv("ANDROMEDA_URL")
     ANDROMEDA_API_KEY = os.getenv("ANDROMEDA_API_KEY")
     ANDROMEDA_SERVER_IP = os.getenv("ANDROMEDA_IP")  # shown to participants
     ANDROMEDA_TIMEOUT = float(os.getenv("ANDROMEDA_TIMEOUT", 5))
+else:
+    CHALLENGE_SERVER_ENABLED = False
 
 INSTALLED_PLUGINS = [
     "plugins.flag.hashed",


### PR DESCRIPTION
Resolves #267

This is a little messy as it needs to handle old environments where we
didn't require explicitly setting this.

It also has the worst test I've written in a while, but this should
bring coverage up a bit.
