### PR TITLE
Handle missing TTY

### DIFF
--- a/src/admin/models.py
+++ b/src/admin/models.py
@@ -15,7 +15,11 @@ class AuditLogEntry(models.Model):
 
     @classmethod
     def create_management_entry(cls, command: str, extra=None):
-        AuditLogEntry.objects.create(user=None, username=f"System ({os.getlogin()})",
+        try:
+            user = os.getlogin()
+        except OSError:
+            user = "No TTY"
+        AuditLogEntry.objects.create(user=None, username=f"System ({user})",
                                      action=f"management_{command}", extra=extra)
 
     @classmethod


### PR DESCRIPTION
`os.getlogin()` fails if not running from a TTY. We should handle that so commands don't fail under most environments.

Resolves #286