### PR TITLE
Disable Postgres logging during tests for new table

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
         run: sleep 10
 
       - name: Generate Test Fixtures
-        run: docker exec -w /app --tty $(docker-compose ps -q backend) make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000"
+        run: docker exec -w /app --tty $(docker-compose ps -q backend) make fake-data ARGS="--teams 10 --users 2 --categories 10 --challenges 100 --solves 1000 --zoom"
 
       - name: Confirm Upstream is Healthy
         run: curl -v --fail localhost:8000/api/v2/stats/stats/

--- a/scripts/fake/__init__.py
+++ b/scripts/fake/__init__.py
@@ -1,12 +1,13 @@
 """A command-line tool for generating and inserting many rows of fake data into the database.
 
 Usage:
-    fake generate [--teams=<teams>] [--users=<users>] [--categories=<categories>] [--challenges=<challenges>] [--solves=<solves>] [--force]
+    fake generate [--teams=<teams>] [--users=<users>] [--categories=<categories>] [--challenges=<challenges>] [--solves=<solves>] [--force] [--zoom]
     fake -h | --help
 
 Options:
     --help -h                  Show this screen.
     --force                    Run even when the database is populated.
+    --zoom                     Disable Postgres logging so the script runs faster.
 
     --users=<users>            The number of users to generate per team.           [default: 2]
     --categories=<categories>  The number of categories to generate.               [default: 5]

--- a/scripts/fake/__main__.py
+++ b/scripts/fake/__main__.py
@@ -51,9 +51,10 @@ try:
         db_indexes[table] = indexes
         db_constraints[table] = constraints
 
-    for table in TABLE_NAMES:
-        cursor.execute(f"ALTER TABLE {table} SET UNLOGGED")
-        db.connection.commit()
+    if arguments.get("zoom"):
+        for table in TABLE_NAMES:
+            cursor.execute(f"ALTER TABLE {table} SET UNLOGGED")
+            db.connection.commit()
 
     with TimedLog("Inserting data... ", ending="\n"):
         fake = Faker()

--- a/scripts/fake/config.py
+++ b/scripts/fake/config.py
@@ -28,6 +28,7 @@ FORCE = arguments.get("--force")
 
 
 TABLE_NAMES = [
+    "admin_auditlogentry",
     "member_member_groups",
     "authentication_token",
     "member_member_user_permissions",


### PR DESCRIPTION
The `auditlog` table is marked as `logged` in Postgres, so it can't have foreign key references to unlogged tables. To speed up test fixture generation, we disable Postgres logging.

This patch adds `auditlog` to the list of tables we disable logging on and makes disabling logging optional.
